### PR TITLE
Fix id ignore example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ var processors: {
     },
     ignores: {
         classes: ['hidden', 'active']   // ignore these class selectors,
-        id: false                       //don't touch IDs
+        ids: '*'                        // ignore all IDs
     };
 
 gs.run(processors, ignores);


### PR DESCRIPTION
`id: false` isn't working, `ids: '*'` will do.