### PR TITLE
fix short name generator, so that it doesn't generate ignored class names

### DIFF
--- a/lib/utils/library.js
+++ b/lib/utils/library.js
@@ -30,7 +30,8 @@ function Library(ignores) {
 	};
 
 	/**
-	 * Ensures the name is set and returns it.
+	 * Ensures the name is set and returns it. If generates an ignored name,
+	 * will increase size and try again
 	 *
 	 * @param name String name to get shortname for from the library
 	 * @param dontCount Bool to not to count this as a use in the code
@@ -48,12 +49,15 @@ function Library(ignores) {
 				_library[name].hits++;
 			}
 		} else if (!multimatch(name, _ignores).length) {
-			shortname = generateShortname(size);
+			do {
+				shortname = generateShortname(size);
+				size++;
+			} while (~_ignores.indexOf(shortname));
+
 			_library[name] = {
 				shortname: shortname,
 				hits: dontCount ? 0 : 1
 			};
-			size++;
 		} else {
 			shortname = name;
 		}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-selectors",
   "description": "Minify CSS selectors.",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "author": {
     "name": "Caleb Brewer",
     "email": "calebthebrewer@gmail.com"

--- a/test/processors/css.test.js
+++ b/test/processors/css.test.js
@@ -14,6 +14,15 @@ vows.describe('CSS Replacer').addBatch({
 			assert.equal(minified, '.a{property:value;}')
 		}
 	},
+	'A class name with an ignore': {
+		topic: '.a{color: red;} .cat{color:blue}',
+		'should not redefine other classes with the ignored class name': function(topic) {
+			var classLibrary = new Library(['a']),
+				minified = css(topic, classLibrary);
+
+			assert.equal(minified, '.a{color: red;} .b{color:blue}');
+		}
+	},
 	'An id name': {
 		topic: '#hello-selector{property:value;}',
 		'should be minified': function(topic) {


### PR DESCRIPTION
I was running into a problem where i was ignoring the class name "in".

For example i had the classes…  `fade in` on an element and `{ignore: { classes: ['in'] }}` in my options.

Then when my obfuscated classes made it up into the `im in io ip` etc it redefined my `in` class.

This fixes that problem - i also added a test - let me know if anything else i can do.

Thanks!