### PR TITLE
Fixes calebthebrewer/gulp-selectors/issues/23

### DIFF
--- a/lib/utils/expressions.js
+++ b/lib/utils/expressions.js
@@ -57,7 +57,7 @@ module.exports = {
 	 * - name="selector"
 	 * - href="selector"
 	 */
-	elementAttribute: /(class|id|for)\s*=\s*["'](-?[_a-zA-Z]+[_\w-\s]*)["']/g,
+	elementAttribute: /(class|id|for|aria-labelledby)\s*=\s*["'](-?[_a-zA-Z]+[_\w-\s]*)["']/g,
 	/**
 	 * Matches ID Values
 	 * 

--- a/test/expressions/expressions.element-attribute.test.js
+++ b/test/expressions/expressions.element-attribute.test.js
@@ -38,5 +38,11 @@ vows.describe('Expressions: element attribute').addBatch({
 		'should return a match': function(topic) {
 			assert.equal(topic.length, 1);
 		}
+	},
+	'An aria-labelledby attribute': {
+		topic: 'aria-labelledby="selector"'.match(expressions.elementAttribute),
+		'should return a match': function(topic) {
+			assert.equal(topic.length, 1);
+		}
 	}
 }).export(module);


### PR DESCRIPTION
aria-labelledby attribute now has its values replaced with minified IDs.